### PR TITLE
Feature/graph changes

### DIFF
--- a/src/API/details.ts
+++ b/src/API/details.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import utils from './utils'
 const baseRoutes = {
   async getNodeDetails(nodeId: string) {
-    let config = {
+    const config = {
       method: 'get',
       maxBodyLength: Infinity,
       url: `https://robokop-automat.apps.renci.org/robokopkg/node/${nodeId}`,
@@ -31,7 +31,7 @@ const baseRoutes = {
     predicate: string,
     category?: string,
   ) {
-    let config = {
+    const config = {
       method: 'get',
       maxBodyLength: Infinity,
       url: `https://robokop-automat.apps.renci.org/robokopkg/edges/${nodeId}?limit=${pageSize}&offset=${
@@ -56,7 +56,7 @@ const baseRoutes = {
   },
 
   async getNodeEdgeSummary(nodeId: string) {
-    let config = {
+    const config = {
       method: 'get',
       maxBodyLength: Infinity,
       url: `https://robokop-automat.apps.renci.org/robokopkg/edge_summary/${nodeId}`,
@@ -78,7 +78,7 @@ const baseRoutes = {
   },
 
   async getNodeEdgeCount(nodeId: string) {
-    let config = {
+    const config = {
       method: 'get',
       maxBodyLength: Infinity,
       url: `https://robokop-automat.apps.renci.org/robokopkg/edges/${nodeId}?count_only=true`,

--- a/src/API/graphRegistry.ts
+++ b/src/API/graphRegistry.ts
@@ -1,13 +1,18 @@
 import axios from 'axios'
 
-export const GRAPH_REGISTRY_ROUTE = 'https://graph-registry.apps.renci.org'
+export const GRAPH_REGISTRY_ROUTE = 'https://robokop-graph-registry.apps.renci.org'
 
 export interface GraphRegistryEntry {
   graph_id: string
   summary: string
   name: string
-  node_count: number
-  edge_counts: number
+  nodes_count: number
+  edges_counts: number
+}
+
+export interface GraphDownloadData {
+  file_path: string
+  file_size_bytes: number
 }
 
 export const graphRegistryList = async (): Promise<GraphRegistryEntry[]> => {
@@ -16,5 +21,46 @@ export const graphRegistryList = async (): Promise<GraphRegistryEntry[]> => {
     return response.data
   } else {
     throw new Error(`Failed to fetch graph registry: ${response.statusText}`)
+  }
+}
+
+export const graphSchema = async (graph_id: string, graph_version: string) => {
+  const response = await axios.get(`${GRAPH_REGISTRY_ROUTE}/schema/${graph_id}/${graph_version}`)
+  if (response.status === 200) {
+    return response.data
+  } else {
+    throw new Error(`Failed to fetch graph schema: ${response.statusText}`)
+  }
+}
+
+export const graphMetadata = async (graph_id: string, graph_version: string) => {
+  const response = await axios.get(
+    `${GRAPH_REGISTRY_ROUTE}/graph_metadata/${graph_id}/${graph_version}`,
+  )
+  if (response.status === 200) {
+    return response.data
+  } else {
+    throw new Error(`Failed to fetch graph metadata: ${response.statusText}`)
+  }
+}
+
+export const getGraphDownloadList = async (
+  graph_id: string,
+  graph_version: string,
+): Promise<GraphDownloadData[]> => {
+  const response = await axios.get(`${GRAPH_REGISTRY_ROUTE}/files/${graph_id}/${graph_version}`)
+  if (response.status === 200) {
+    return response.data
+  } else {
+    throw new Error(`Failed to fetch graph download list: ${response.statusText}`)
+  }
+}
+
+export const getGraphVersionList = async (graph_id: string): Promise<string[]> => {
+  const response = await axios.get(`${GRAPH_REGISTRY_ROUTE}/versions/${graph_id}`)
+  if (response.status === 200) {
+    return response.data
+  } else {
+    throw new Error(`Failed to fetch graph version list: ${response.statusText}`)
   }
 }

--- a/src/API/graphRegistry.ts
+++ b/src/API/graphRegistry.ts
@@ -1,0 +1,20 @@
+import axios from 'axios'
+
+export const GRAPH_REGISTRY_ROUTE = 'https://graph-registry.apps.renci.org'
+
+export interface GraphRegistryEntry {
+  graph_id: string
+  summary: string
+  name: string
+  node_count: number
+  edge_counts: number
+}
+
+export const graphRegistryList = async (): Promise<GraphRegistryEntry[]> => {
+  const response = await axios.get(`${GRAPH_REGISTRY_ROUTE}/registry`)
+  if (response.status === 200) {
+    return response.data
+  } else {
+    throw new Error(`Failed to fetch graph registry: ${response.statusText}`)
+  }
+}

--- a/src/components/DownloadDialog.tsx
+++ b/src/components/DownloadDialog.tsx
@@ -60,7 +60,7 @@ const constructCsvObj = (message: {
     `${node_label} (CURIE)`,
   ])
 
-  let csvHeaderEdgeLabelsMerged = new Set()
+  const csvHeaderEdgeLabelsMerged = new Set()
   message.results.forEach(
     (result: {
       node_bindings: ArrayLike<unknown> | { [s: string]: unknown }

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -128,7 +128,7 @@ function Header() {
           open={exploreMenuOpen}
           onClose={closeExploreMenu}
           items={[
-            { to: '/explore/graphs', label: 'Graphs' },
+            { to: '/graphs', label: 'Graphs' },
             { to: '/details', label: 'Node Explorer' },
             { to: '/explore/enrichment-analysis', label: 'Enrichment Analysis' },
             { to: '/explore/drug-chemical', label: 'Drug to Disease Pair' },

--- a/src/pages/answer/Answer.tsx
+++ b/src/pages/answer/Answer.tsx
@@ -45,8 +45,8 @@ interface EdgeType {
   strokeWidth?: number
   numEdges?: number
   index?: number
-  attributes?: any[]
-  sources?: any[]
+  attributes?: unknown[]
+  sources?: unknown[]
 }
 interface AnswerStoreType {
   numQgNodes: number
@@ -56,19 +56,20 @@ interface AnswerStoreType {
     edges: { [id: string]: EdgeType }
   }
   selectedRowId: string
-  metaData?: any
+  metaData?: Record<string, unknown>
   resultJSON: {
     knowledge_graph: {
-      edges: { [id: string]: { attributes: any[]; sources: any[] } }
+      nodes: { [id: string]: { name?: string; categories?: string[]; attributes?: unknown[] } }
+      edges: { [id: string]: { attributes: unknown[]; sources: unknown[]; qualifiers?: unknown[] } }
     }
-    result?: any
+    result?: unknown
   }
-  tableHeaders: any[]
+  tableHeaders: unknown[]
   message: {
-    results: any[]
-    [key: string]: any
+    results: unknown[]
+    [key: string]: unknown
   }
-  selectRow: (row: any, id: string | number) => void
+  selectRow: (row: unknown, id: string | number) => void
 }
 
 interface DisplayStateItem {
@@ -121,12 +122,14 @@ export default function Answer({ answer_id }: AnswerProps) {
    * Validate a TRAPI message and either display any errors or initialize the answer store
    * @param answerResponse - Either an object with error message or stringified message object
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function validateAndInitializeMessage(answerResponse: any): void {
     if (answerResponse && answerResponse.status && answerResponse.status === 'error') {
       pageStatus.setFailure(answerResponse.message)
       return
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let answerResponseJSON: any
     try {
       answerResponseJSON = JSON.parse(answerResponse)
@@ -238,6 +241,7 @@ export default function Answer({ answer_id }: AnswerProps) {
           })
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [answer_id, isLoading])
 
   /**
@@ -252,6 +256,7 @@ export default function Answer({ answer_id }: AnswerProps) {
       fr.onload = (e) => {
         if (!e.target) return
         const fileContents = e.target.result
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let msg: any = {}
         try {
           msg = JSON.parse(typeof fileContents === 'string' ? fileContents : '')
@@ -411,6 +416,7 @@ export default function Answer({ answer_id }: AnswerProps) {
                 )}
                 {displayState.kgFull.show && answerStore.message.knowledge_graph && (
                   <KgFull
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     message={answerStore.message as { knowledge_graph: { nodes: any; edges: any } }}
                   />
                 )}

--- a/src/pages/answer/NodeAttributesTable.tsx
+++ b/src/pages/answer/NodeAttributesTable.tsx
@@ -30,6 +30,11 @@ interface NodeData {
   id?: string | number | (string | number)[]
   categories?: string | number | (string | number)[]
   count?: string | number | (string | number)[]
+  attributes?: Array<{
+    attribute_type_id?: string
+    original_attribute_name?: string
+    value?: string | number | boolean | (string | number | boolean)[]
+  }>
 }
 
 interface NodeAttributesTableProps {
@@ -37,7 +42,7 @@ interface NodeAttributesTableProps {
 }
 
 const NodeAttributesTable: React.FC<NodeAttributesTableProps> = ({ nodeData }) => {
-  const { name, id, categories, count } = nodeData
+  const { name, id, categories, count, attributes } = nodeData
 
   return (
     <Box style={{ maxHeight: 500, overflow: 'auto' }}>
@@ -79,6 +84,26 @@ const NodeAttributesTable: React.FC<NodeAttributesTableProps> = ({ nodeData }) =
               <ValueCell value={count} />
             </TableRow>
           )}
+
+          {Array.isArray(attributes) &&
+            attributes.map((attribute, index) => (
+              <TableRow key={`attribute-${index}`} style={{ verticalAlign: 'top' }}>
+                <TableCell>
+                  {attribute.original_attribute_name || attribute.attribute_type_id}
+                </TableCell>
+                <TableCell>
+                  <ul style={{ padding: 0, margin: 0, listStyleType: 'none' }}>
+                    {Array.isArray(attribute.value) ? (
+                      attribute.value.map((valueItem, valueIndex) => (
+                        <li key={valueIndex}>{valueItem}</li>
+                      ))
+                    ) : (
+                      <li>{attribute.value}</li>
+                    )}
+                  </ul>
+                </TableCell>
+              </TableRow>
+            ))}
         </StyledTableBody>
       </Table>
     </Box>

--- a/src/pages/answer/fullKg/KgFull.tsx
+++ b/src/pages/answer/fullKg/KgFull.tsx
@@ -124,7 +124,6 @@ export default function KgFull({ message }: KgFullProps) {
           break
         }
         default:
-          // eslint-disable-next-line no-console
           console.log('unhandled worker message')
       }
     }

--- a/src/pages/answer/resultsTable/AttributesTable.tsx
+++ b/src/pages/answer/resultsTable/AttributesTable.tsx
@@ -1,15 +1,19 @@
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 import { Box, Button, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import SummaryModal from './SummaryModal'
 import { useAuth } from '../../../context/AuthContext'
-import { isPremiumOrAdmin } from '../../../utils/roles'
 import LoginWarning from '../leftDrawer/LoginWarning'
 import { useFeatureAccess } from '../../../hooks'
 
 interface Attribute {
   attribute_type_id: string
-  value: string | string[]
+  value: string | number | boolean | (string | number | boolean)[]
+}
+
+interface Qualifier {
+  qualifier_type_id: string
+  qualifier_value: string
 }
 
 interface Source {
@@ -21,6 +25,7 @@ interface Source {
 interface AttributesTableProps {
   attributes: Attribute[]
   sources: Source[]
+  qualifiers?: Qualifier[]
 }
 
 const headerStyles = { fontWeight: 'bold', backgroundColor: '#eee' }
@@ -31,7 +36,9 @@ const StyledTableBody = styled(TableBody)(() => ({
   },
 }))
 
-const ValueCell: React.FC<{ value: string | string[] }> = ({ value }) => (
+const ValueCell: React.FC<{ value: string | number | boolean | (string | number | boolean)[] }> = ({
+  value,
+}) => (
   <TableCell>
     <ul style={{ padding: 0, margin: 0, listStyleType: 'none' }}>
       {Array.isArray(value) ? (
@@ -127,7 +134,7 @@ const PublicationLinkCell: React.FC<{ value: string | string[] }> = ({ value }) 
   )
 }
 
-const AttributesTable: React.FC<AttributesTableProps> = ({ attributes, sources }) => (
+const AttributesTable: React.FC<AttributesTableProps> = ({ attributes, sources, qualifiers }) => (
   <Box style={{ maxHeight: 500, maxWidth: 800, overflow: 'auto' }}>
     <Table size='small' aria-label='edge attributes table'>
       <TableHead style={{ position: 'sticky', top: 0 }}>
@@ -142,13 +149,26 @@ const AttributesTable: React.FC<AttributesTableProps> = ({ attributes, sources }
             <TableCell style={{ verticalAlign: 'top' }}>{attribute.attribute_type_id}</TableCell>
             {attribute.attribute_type_id === 'biolink:publications' ? (
               <>
-                <PublicationLinkCell value={attribute.value} />
+                <PublicationLinkCell
+                  value={
+                    Array.isArray(attribute.value)
+                      ? attribute.value.map((valueItem) => String(valueItem))
+                      : String(attribute.value)
+                  }
+                />
               </>
             ) : (
               <ValueCell value={attribute.value} />
             )}
           </TableRow>
         ))}
+        {Array.isArray(qualifiers) &&
+          qualifiers.map((qualifier, index) => (
+            <TableRow key={`qualifier-${index}`}>
+              <TableCell style={{ verticalAlign: 'top' }}>{qualifier.qualifier_type_id}</TableCell>
+              <TableCell style={{ verticalAlign: 'top' }}>{qualifier.qualifier_value}</TableCell>
+            </TableRow>
+          ))}
         <TableRow>
           <TableCell>Sources</TableCell>
           <TableCell>

--- a/src/pages/answer/resultsTable/ResultExplorer.tsx
+++ b/src/pages/answer/resultsTable/ResultExplorer.tsx
@@ -47,6 +47,7 @@ interface EdgeType extends d3.SimulationLinkDatum<NodeType> {
   index?: number
   attributes?: any[]
   sources?: any[]
+  qualifiers?: any[]
 }
 
 interface AnswerStoreType {
@@ -60,7 +61,8 @@ interface AnswerStoreType {
   metaData?: any
   resultJSON: {
     knowledge_graph: {
-      edges: { [id: string]: { attributes: any[]; sources: any[] } }
+      nodes: { [id: string]: { name?: string; categories?: string[]; attributes?: any[] } }
+      edges: { [id: string]: { attributes: any[]; sources: any[]; qualifiers?: any[] } }
     }
   }
 }
@@ -69,7 +71,7 @@ type PopoverType = 'node' | 'edge' | null
 
 type PopoverDataType =
   | Pick<NodeType, 'name' | 'id' | 'categories'>
-  | Pick<EdgeType, 'attributes' | 'sources'>
+  | Pick<EdgeType, 'attributes' | 'sources' | 'qualifiers'>
   | object
 
 /**
@@ -253,6 +255,7 @@ export default function ResultExplorer({ answerStore }: { answerStore: AnswerSto
         ...answerStore.selectedResult.edges[key],
         attributes: answerStore.resultJSON.knowledge_graph.edges[key]?.attributes,
         sources: answerStore.resultJSON.knowledge_graph.edges[key]?.sources,
+        qualifiers: answerStore.resultJSON.knowledge_graph.edges[key]?.qualifiers,
       }))
     const edges: EdgeType[] = trimmedEdges.map((d) => ({ ...d }))
     simulation.current.nodes(nodes)
@@ -440,14 +443,16 @@ export default function ResultExplorer({ answerStore }: { answerStore: AnswerSto
   const handleClickNode = (data: NodeType) => {
     if (!svgRef.current) return
     const { top, left } = svgRef.current.getBoundingClientRect()
+    const nodeDetails = answerStore.resultJSON.knowledge_graph.nodes?.[data.id]
     setPopoverPosition({
       x: left + (data.x ?? 0),
       y: top + (data.y ?? 0),
     })
     setPopoverData({
-      name: data.name,
+      name: nodeDetails?.name || data.name,
       id: data.id,
-      categories: data.categories,
+      categories: nodeDetails?.categories || data.categories,
+      attributes: nodeDetails?.attributes || [],
     })
     setPopoverOpen('node')
   }
@@ -490,6 +495,7 @@ export default function ResultExplorer({ answerStore }: { answerStore: AnswerSto
           <AttributesTable
             attributes={(popoverData as any).attributes}
             sources={(popoverData as any).sources}
+            qualifiers={(popoverData as any).qualifiers}
           />
         )}
       </Popover>

--- a/src/pages/answer/resultsTable/ResultExplorer.tsx
+++ b/src/pages/answer/resultsTable/ResultExplorer.tsx
@@ -70,7 +70,7 @@ type PopoverType = 'node' | 'edge' | null
 type PopoverDataType =
   | Pick<NodeType, 'name' | 'id' | 'categories'>
   | Pick<EdgeType, 'attributes' | 'sources'>
-  | {}
+  | object
 
 /**
  * Selected result graph

--- a/src/pages/answer/resultsTable/ResultMetaData.tsx
+++ b/src/pages/answer/resultsTable/ResultMetaData.tsx
@@ -11,14 +11,11 @@ import {
 } from '@mui/material'
 import ExpandLess from '@mui/icons-material/ExpandLess'
 import ExpandMore from '@mui/icons-material/ExpandMore'
-// @ts-ignore
-import shortid from 'shortid'
 import Markdown from 'react-markdown'
 import { transformKGToMinimalDynamic } from './metaDataTransformation'
 import { useQuery } from '@tanstack/react-query'
 import { llmRoutes } from '../../../API/routes'
 import { useAuth } from '../../../context/AuthContext'
-import { isPremiumOrAdmin } from '../../../utils/roles'
 import { useFeatureAccess } from '../../../hooks'
 
 interface ExpansionState {

--- a/src/pages/answer/resultsTable/ResultsTable.tsx
+++ b/src/pages/answer/resultsTable/ResultsTable.tsx
@@ -67,7 +67,8 @@ interface AnswerStoreType {
   metaData?: any
   resultJSON: {
     knowledge_graph: {
-      edges: { [id: string]: { attributes: any[]; sources: any[] } }
+      nodes: { [id: string]: { name?: string; categories?: string[]; attributes?: any[] } }
+      edges: { [id: string]: { attributes: any[]; sources: any[]; qualifiers?: any[] } }
     }
     result?: any
   }

--- a/src/pages/graph/Graph.tsx
+++ b/src/pages/graph/Graph.tsx
@@ -66,12 +66,12 @@ function Graph({ graphData, isLoading }: GraphProps) {
                       </div>
                       <div>
                         <Chip
-                          label={`Nodes: ${stringUtils.formatNumber(graph.node_count) || '—'}`}
+                          label={`Nodes: ${stringUtils.formatNumber(graph.nodes_count) || '—'}`}
                           size='small'
                           sx={{ mr: 1, fontSize: '0.75rem' }}
                         />
                         <Chip
-                          label={`Edges: ${stringUtils.formatNumber(graph.edge_counts) || '—'}`}
+                          label={`Edges: ${stringUtils.formatNumber(graph.edges_counts) || '—'}`}
                           size='small'
                           sx={{ fontSize: '0.75rem' }}
                         />
@@ -94,7 +94,7 @@ function Graph({ graphData, isLoading }: GraphProps) {
                     <Link
                       className='details-card-button'
                       to='/graphs/$graph_id'
-                      params={{ graph_id: graphIdWithoutAutomat(graph.graph_id) }}
+                      params={{ graph_id: graph.graph_id }}
                     >
                       Details →
                     </Link>

--- a/src/pages/graph/Graph.tsx
+++ b/src/pages/graph/Graph.tsx
@@ -3,13 +3,17 @@ import { Chip, Container, Skeleton, styled, Typography } from '@mui/material'
 import { Link } from '@tanstack/react-router'
 import stringUtils from '../../utils/strings'
 import '../details/Details.css'
+import { GraphRegistryEntry } from '../../API/graphRegistry'
 
 interface GraphProps {
-  graphData: any[]
+  graphData: GraphRegistryEntry[]
   isLoading?: boolean
 }
 
 function Graph({ graphData, isLoading }: GraphProps) {
+  const graphIdWithoutAutomat = (graphId: string) => {
+    return graphId.replace(/_Automat$/, '')
+  }
   return (
     <Container sx={{ width: '100%', maxWidth: 1200, my: 8 }}>
       <Typography variant='h4' component='h1' mb={1} sx={{ fontWeight: 500, textAlign: 'center' }}>
@@ -62,12 +66,12 @@ function Graph({ graphData, isLoading }: GraphProps) {
                       </div>
                       <div>
                         <Chip
-                          label={`Nodes: ${stringUtils.formatNumber(graph.totalNodeCount) || '—'}`}
+                          label={`Nodes: ${stringUtils.formatNumber(graph.node_count) || '—'}`}
                           size='small'
                           sx={{ mr: 1, fontSize: '0.75rem' }}
                         />
                         <Chip
-                          label={`Edges: ${stringUtils.formatNumber(graph.totalEdgeCount) || '—'}`}
+                          label={`Edges: ${stringUtils.formatNumber(graph.edge_counts) || '—'}`}
                           size='small'
                           sx={{ fontSize: '0.75rem' }}
                         />
@@ -75,7 +79,7 @@ function Graph({ graphData, isLoading }: GraphProps) {
                     </div>
 
                     <div className='details-card-value'>
-                      {graph.description || 'No description available'}
+                      {graph.summary || 'No description available'}
                     </div>
                   </div>
                   <div
@@ -90,7 +94,7 @@ function Graph({ graphData, isLoading }: GraphProps) {
                     <Link
                       className='details-card-button'
                       to='/graphs/$graph_id'
-                      params={{ graph_id: graph.graph_id }}
+                      params={{ graph_id: graphIdWithoutAutomat(graph.graph_id) }}
                     >
                       Details →
                     </Link>

--- a/src/pages/graph/Graph.tsx
+++ b/src/pages/graph/Graph.tsx
@@ -89,7 +89,7 @@ function Graph({ graphData, isLoading }: GraphProps) {
                   >
                     <Link
                       className='details-card-button'
-                      to='/explore/graphs/$graph_id'
+                      to='/graphs/$graph_id'
                       params={{ graph_id: graph.graph_id }}
                     >
                       Details →

--- a/src/pages/graphId/BreadcrumbsComponent.tsx
+++ b/src/pages/graphId/BreadcrumbsComponent.tsx
@@ -6,7 +6,7 @@ function BreadcrumbsComponent({ displayName }: { displayName: string }) {
     <Breadcrumbs aria-label='graph breadcrumbs'>
       <Typography
         component={Link}
-        to='/explore/graphs'
+        to='/graphs'
         color='text.secondary'
         variant='body2'
         sx={{ textDecoration: 'none' }}

--- a/src/pages/graphId/Download.tsx
+++ b/src/pages/graphId/Download.tsx
@@ -27,20 +27,19 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import { formatFileSize } from '../../utils/getFileSize'
 import { formatBuildDate } from '../../utils/dateTime'
-import { getGraphMetadataDownloads } from '../../functions/graphFunctions'
+import { getGraphDownloadList } from '../../API/graphRegistry'
 
-function DownloadSection() {
+interface DownloadSectionProps {
+  version: string
+}
+
+function DownloadSection({ version }: DownloadSectionProps) {
   const { graph_id } = useParams({ strict: false })
-  const [expanded, setExpanded] = React.useState<string | false>(false)
 
   const { data: downloadData, isLoading: isLoadingDownload } = useQuery({
-    queryKey: ['graph-metadata', graph_id, 'download'],
-    queryFn: () => getGraphMetadataDownloads(graph_id!),
+    queryKey: ['graph-metadata', graph_id, version, 'download'],
+    queryFn: () => getGraphDownloadList(graph_id!, version!),
   })
-
-  const handleChange = (panel: string) => (event: React.SyntheticEvent, isExpanded: boolean) => {
-    setExpanded(isExpanded ? panel : false)
-  }
 
   const renderSkeleton = () => (
     <Box>
@@ -74,16 +73,85 @@ function DownloadSection() {
   )
 
   return (
-    <Box sx={{ marginTop: '36px' }} id='download'>
+    <Box sx={{ marginTop: '36px', minWidth: '400px' }} id='download'>
       <Card variant='outlined'>
-        <CardHeader title='Releases and Download Options' sx={{ pb: 0 }} />
+        <CardHeader title='Download Options' sx={{ pb: 0 }} />
         <CardContent>
           <Box>
             {isLoadingDownload ? (
               renderSkeleton()
-            ) : downloadData?.data?.length > 0 ? (
+            ) : downloadData && downloadData.length > 0 ? (
               <Box>
-                {[...downloadData.data].reverse().map((file: any, index: number) => (
+                <TableContainer>
+                  <Table size='small'>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>
+                          <Typography variant='subtitle2' fontWeight='bold'>
+                            File Name
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant='subtitle2' fontWeight='bold'>
+                            Size
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {downloadData.map((link, idx: number) => (
+                        <TableRow
+                          key={idx}
+                          sx={{
+                            '&:hover': {
+                              backgroundColor: 'action.hover',
+                            },
+                          }}
+                        >
+                          <TableCell>
+                            <Link
+                              href={`${window.location.origin}/graphs/${link.file_path.replace(/^\/+/, '')}`}
+                              target='_blank'
+                              rel='noopener noreferrer'
+                              sx={{
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: 0.5,
+                                textDecoration: 'none',
+                                color: 'primary.main',
+                                '&:hover': {
+                                  textDecoration: 'underline',
+                                },
+                              }}
+                            >
+                              <OpenInNewIcon fontSize='small' />
+                              <Typography variant='body2' fontWeight={500}>
+                                {link.file_path.split('/').pop() || 'Download'}
+                              </Typography>
+                            </Link>
+                          </TableCell>
+                          <TableCell>
+                            <Typography variant='body2' color='text.secondary'>
+                              {link.file_size_bytes
+                                ? formatFileSize(link.file_size_bytes)
+                                : 'Unknown'}
+                            </Typography>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Box>
+            ) : (
+              renderEmptyState()
+            )}
+            {/* {renderEmptyState()} */}
+            {/* {isLoadingDownload ? (
+              renderSkeleton()
+            ) : downloadData && downloadData.length > 0 ? (
+              <Box>
+                {downloadData.map((file, index: number) => (
                   <Accordion
                     key={index}
                     expanded={expanded === file.id}
@@ -145,11 +213,7 @@ function DownloadSection() {
                                     Upload Date
                                   </Typography>
                                 </TableCell>
-                                {/* <TableCell align="center">
-                            <Typography variant="subtitle2" fontWeight="bold">
-                              Action
-                            </Typography>
-                          </TableCell> */}
+
                               </TableRow>
                             </TableHead>
                             <TableBody>
@@ -214,7 +278,7 @@ function DownloadSection() {
               </Box>
             ) : (
               renderEmptyState()
-            )}
+            )} */}
           </Box>
         </CardContent>
       </Card>

--- a/src/pages/graphId/GraphId.tsx
+++ b/src/pages/graphId/GraphId.tsx
@@ -5,14 +5,12 @@ import axios from 'axios'
 import React from 'react'
 import { GraphMetadataV2, GraphSchemaV2 } from '../../API/graphMetadata'
 import { fileRoutes } from '../../API/routes'
-import { getGraphMetadataDownloads } from '../../functions/graphFunctions'
 import DownloadSection from '../graphId/Download'
 import '../graphId/GraphId.css'
 import NodeCuriePrefixes from '../graphId/NodeCuriePrefixes'
 import PredicateCount from '../graphId/PredicateCount'
 import PrimaryKnowledgeSources from '../graphId/PrimaryKnowledgeSources'
 import SankeyGraphModal from '../graphId/SankeyGraphModal'
-import StringTableDisplay from '../graphId/StringTableDisplay'
 import BreadcrumbsComponent from './BreadcrumbsComponent'
 import ConformanceSchema from './ConformanceSchema'
 import ContactPoint from './ContactPoint'
@@ -23,11 +21,22 @@ import SidebarV2 from './Sidebar'
 import { getAttributesAndCounts, transformSchemaToLinks } from './functions'
 import NodeProperties from './NodeProperties'
 import EdgeProperties from './EdgeProperties'
+import {
+  getGraphDownloadList,
+  getGraphVersionList,
+  GraphDownloadData,
+  graphMetadata,
+} from '../../API/graphRegistry'
+import Releases from './Releases'
 
 const COMMON_SIDEBAR_ITEMS = [
   {
     title: 'Description',
     id: 'description',
+  },
+  {
+    title: 'Releases',
+    id: 'releases',
   },
   {
     title: 'Download',
@@ -93,7 +102,7 @@ function GraphId({ v2Metadata, schemaV2 }: GraphIdV2Props) {
     downloadLink!.replace('https://robokop.renci.org', 'https://stars.renci.org/var/plater') +
     'neo4j.dump'
   const { data: fileSize } = useQuery({
-    queryKey: ['graph-metadata-v2', graph_id, 'file-size'],
+    queryKey: ['graph-metadata', graph_id, 'file-size'],
     queryFn: async () => {
       const results = await axios.post(fileRoutes.fileSize, {
         fileUrl: validDownloadLink,
@@ -101,22 +110,36 @@ function GraphId({ v2Metadata, schemaV2 }: GraphIdV2Props) {
       return results.data.size
     },
   })
+
+  const displayVersion = v2Metadata?.version || 'N/A'
   const { data: downloadData } = useQuery({
-    queryKey: ['graph-metadata', graph_id, 'download'],
-    queryFn: () => getGraphMetadataDownloads(graph_id!),
+    queryKey: ['graph-metadata', graph_id, displayVersion, 'download'],
+    queryFn: () => getGraphDownloadList(graph_id!, displayVersion!),
   })
+
+  const { data: releaseData, isLoading: isReleaseDataLoading } = useQuery({
+    queryKey: ['releases', graph_id],
+    queryFn: () => getGraphVersionList(graph_id!),
+    enabled: !!graph_id,
+  })
+  const isLatestInReleaseData = releaseData?.find((v) => v === 'latest') !== undefined
+  const { data: schemaV2Latest } = useQuery({
+    queryKey: ['graph-metadata', graph_id, 'latest'],
+    queryFn: () => graphMetadata(graph_id!, 'latest'),
+    enabled: isLatestInReleaseData,
+  })
+  const latestVersionID = schemaV2Latest?.version
 
   const graphDatasetV2 = React.useMemo(() => {
     return schemaV2 ? transformSchemaToLinks(schemaV2) : { nodes: [], links: [] }
   }, [schemaV2])
 
-  const latestMetadataUrl = downloadData?.data
-    ?.at(-1)
-    ?.links?.filter((link: any) => link.url.includes('meta.json'))[0]?.url
+  const latestMetadataUrl = downloadData?.filter((file: GraphDownloadData) =>
+    file.file_path.includes('meta.json'),
+  )?.[0]?.file_path
 
   const displayName = v2Metadata?.name || ''
   const displayDescription = v2Metadata?.description || 'No description available'
-  const displayVersion = v2Metadata?.version || 'N/A'
 
   const edgePropertiesData = getAttributesAndCounts(schemaV2?.schema.edges || [])
 
@@ -195,7 +218,14 @@ function GraphId({ v2Metadata, schemaV2 }: GraphIdV2Props) {
           </Grid>
         </Grid>
       </Box>
-      <DownloadSection />
+      <Box>
+        <Releases
+          latestVersion={latestVersionID}
+          releases={releaseData}
+          loading={isReleaseDataLoading}
+        />
+        <DownloadSection version={displayVersion} />
+      </Box>
     </Container>
   )
 }

--- a/src/pages/graphId/HeaderCard.tsx
+++ b/src/pages/graphId/HeaderCard.tsx
@@ -3,7 +3,7 @@ import { Download, OpenInNew } from '@mui/icons-material'
 import { formatFileSize } from '../../utils/getFileSize'
 import stringUtils from '../../utils/strings'
 import { formatBuildDate } from '../../utils/dateTime'
-import { GraphMetadataV2, GraphSchemaV2 } from '../../API/graphMetadata'
+import { GraphMetadataV2 } from '../../API/graphMetadata'
 
 interface HeaderCardProps {
   displayName: string
@@ -40,6 +40,9 @@ function HeaderCard({
       }
     })
   }
+  const metadataHref = latestMetadataUrl
+    ? `${window.location.origin}/graphs/${latestMetadataUrl.replace(/^\/+/, '')}`
+    : undefined
   return (
     <Card variant='outlined' sx={{ mt: 2 }} id='description'>
       <CardContent>
@@ -135,14 +138,14 @@ function HeaderCard({
               Automat API <OpenInNew sx={{ fontSize: '1.25rem', ml: 0.5 }} />
             </a>
             <p>•</p>
-            {latestMetadataUrl && (
+            {metadataHref && (
               <a
                 className='external-links'
-                href={latestMetadataUrl}
+                href={metadataHref}
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                Latest Metadata <OpenInNew sx={{ fontSize: '1.25rem', ml: 0.5 }} />
+                Metadata <OpenInNew sx={{ fontSize: '1.25rem', ml: 0.5 }} />
               </a>
             )}
             {v2Metadata?.license && (

--- a/src/pages/graphId/PredicateCountDetailsModal.tsx
+++ b/src/pages/graphId/PredicateCountDetailsModal.tsx
@@ -23,9 +23,9 @@ function PredicateCountDetailsModal({
   value: { property: string; count: number }[] | undefined
   sourceKey: string
 }) {
-  let sankeyNodes = new Set<string>(sourceKey ? [sourceKey] : [])
+  const sankeyNodes = new Set<string>(sourceKey ? [sourceKey] : [])
 
-  let sankeyLinks: Array<{ source: string; target: string; value: number }> = []
+  const sankeyLinks: Array<{ source: string; target: string; value: number }> = []
   Object.entries(value || {}).forEach(([_, count]) => {
     sankeyNodes.add(count.property)
     sankeyLinks.push({

--- a/src/pages/graphId/PrimaryKnowledgeSourcesModal.tsx
+++ b/src/pages/graphId/PrimaryKnowledgeSourcesModal.tsx
@@ -23,9 +23,9 @@ function PrimaryKnowledgeSourcesModal({
   value: { property: string; count: number }[] | undefined
   sourceKey: string
 }) {
-  let sankeyNodes = new Set<string>(sourceKey ? [sourceKey] : [])
+  const sankeyNodes = new Set<string>(sourceKey ? [sourceKey] : [])
 
-  let sankeyLinks: Array<{ source: string; target: string; value: number }> = []
+  const sankeyLinks: Array<{ source: string; target: string; value: number }> = []
   Object.entries(value || {}).forEach(([_, count]) => {
     sankeyNodes.add(count.property)
     sankeyLinks.push({

--- a/src/pages/graphId/Releases.tsx
+++ b/src/pages/graphId/Releases.tsx
@@ -1,0 +1,153 @@
+import React from 'react'
+import { useParams } from '@tanstack/react-router'
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Chip,
+  Link,
+  Paper,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import { OpenInNew as OpenInNewIcon, Update as UpdateIcon } from '@mui/icons-material'
+
+export interface ReleasesProps {
+  latestVersion?: string
+  releases?: string[]
+  loading?: boolean
+}
+
+function Releases({ latestVersion, releases, loading }: ReleasesProps) {
+  const { graph_id, graph_version } = useParams({ strict: false })
+
+  const formatVersionList = (versionList: string[], latestVersion: string | undefined) => {
+    return versionList
+      .filter((entry) => entry !== 'latest')
+      .map((entry) => ({
+        version: entry,
+        latest: entry === latestVersion,
+      }))
+  }
+  const formattedReleases = formatVersionList(releases || [], latestVersion)
+
+  const isViewingVersion = (version: string, isLatest: boolean) => {
+    if (!graph_version) return false
+    if (graph_version === 'latest') return isLatest
+    return graph_version === version
+  }
+
+  const renderSkeleton = () => (
+    <Box>
+      {Array(4)
+        .fill('')
+        .map((_, i) => (
+          <Skeleton key={i} variant='rounded' height={44} width={360} sx={{ mb: 1.5 }} />
+        ))}
+    </Box>
+  )
+
+  const renderEmptyState = () => (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 3,
+        textAlign: 'center',
+        border: '2px dashed',
+        borderColor: 'divider',
+        borderRadius: 2,
+      }}
+    >
+      <UpdateIcon sx={{ fontSize: 44, color: 'text.secondary', mb: 1 }} />
+      <Typography variant='subtitle1' color='text.secondary' gutterBottom>
+        No releases available
+      </Typography>
+      <Typography variant='body2' color='text.secondary'>
+        Release history will appear here when available
+      </Typography>
+    </Paper>
+  )
+
+  return (
+    <Box sx={{ marginTop: '36px', minWidth: '400px' }} id='releases'>
+      <Card variant='outlined'>
+        <CardHeader title='Releases' sx={{ pb: 0 }} />
+        <CardContent>
+          {loading ? (
+            renderSkeleton()
+          ) : formattedReleases.length > 0 ? (
+            <TableContainer>
+              <Table size='small'>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>
+                      <Typography variant='subtitle2' fontWeight='bold'>
+                        Version
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {formattedReleases.map((release) => {
+                    const isActiveVersion = isViewingVersion(release.version, release.latest)
+
+                    return (
+                      <TableRow
+                        key={release.version}
+                        sx={{
+                          '&:hover': {
+                            backgroundColor: 'action.hover',
+                          },
+                        }}
+                      >
+                        <TableCell>
+                          <Link
+                            href={`/graphs/${graph_id}/${release.version}`}
+                            sx={{
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              gap: 0.5,
+                              textDecoration: 'none',
+                              color: 'primary.main',
+                              '&:hover': {
+                                textDecoration: 'underline',
+                              },
+                            }}
+                          >
+                            <OpenInNewIcon fontSize='small' />
+                            <Typography variant='body2' fontWeight={isActiveVersion ? 700 : 500}>
+                              {release.version}
+                            </Typography>
+                            {release.latest ? (
+                              <Chip
+                                label='Latest'
+                                size='small'
+                                color='success'
+                                variant='outlined'
+                              />
+                            ) : null}
+                          </Link>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          ) : (
+            renderEmptyState()
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  )
+}
+
+export default Releases

--- a/src/pages/landing/Button/Button.tsx
+++ b/src/pages/landing/Button/Button.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import styles from './Button.module.css'
 
 interface ButtonProps {

--- a/src/pages/landing/Card/Card.tsx
+++ b/src/pages/landing/Card/Card.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributeAnchorTarget } from 'react'
+import React, { type HTMLAttributeAnchorTarget } from 'react'
 import { ExternalLinkIcon } from '../icons/ExternalLinkIcon/ExternalLinkIcon'
 import styles from './Card.module.css'
 import { InternalLinkIcon } from '../icons/InternalLinkIcon/InternalLinkIcon'

--- a/src/pages/landing/CardContainer/CardContainer.tsx
+++ b/src/pages/landing/CardContainer/CardContainer.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import styles from './CardContainer.module.css'
 
 interface CardContainerProps {

--- a/src/pages/landing/CitationList/CitationList.tsx
+++ b/src/pages/landing/CitationList/CitationList.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import styles from './CitationList.module.css'
 
 interface CitationListProps {

--- a/src/pages/landing/ContactForm/recaptcha-context.tsx
+++ b/src/pages/landing/ContactForm/recaptcha-context.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { createContext, useState, useContext, useEffect } from 'react'
+import React, { createContext, useState, useContext, useEffect } from 'react'
 
 interface IRecaptcha {
   enterprise: {
-    ready: Function
-    render: Function
-    reset: Function
-    getResponse: Function
-    execute: Function
+    ready: (callback: () => void) => void
+    render: (element: string | HTMLElement, options: Record<string, unknown>) => string
+    reset: (opt_widget_id?: string) => void
+    getResponse: (opt_widget_id?: string) => string
+    execute: (publicKey: string, options: Record<string, unknown>) => Promise<string>
   }
 }
 

--- a/src/pages/landing/MainGrid/MainGrid.tsx
+++ b/src/pages/landing/MainGrid/MainGrid.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import styles from './MainGrid.module.css'
 
 interface MainGridProps {

--- a/src/pages/landing/Section/Section.tsx
+++ b/src/pages/landing/Section/Section.tsx
@@ -1,5 +1,6 @@
 import styles from './Section.module.css'
 import { toKebabCase } from '../toKebabCase'
+import React from 'react'
 
 interface SectionProps {
   children?: React.ReactNode

--- a/src/pages/landing/icons/IconWrapper/IconWrapper.tsx
+++ b/src/pages/landing/icons/IconWrapper/IconWrapper.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import styles from './IconWrapper.module.css'
 
 interface IconWrapperProps {

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -29,12 +29,7 @@ export default function LandingPage() {
             tool to explore relevant publications.
           </p>
         </Card>
-        <Card
-          title='Explore the Graphs'
-          href='/explore/graphs'
-          icon={<DataIcon />}
-          gradient='purple'
-        >
+        <Card title='Explore the Graphs' href='/graphs' icon={<DataIcon />} gradient='purple'>
           <p>
             Learn about the data in ROBOKOP and explore the knowledge graph using our data browser.
           </p>

--- a/src/pages/queryBuilder/QueryBuilder.tsx
+++ b/src/pages/queryBuilder/QueryBuilder.tsx
@@ -79,7 +79,6 @@ export default function QueryBuilder() {
   // Display modal for the user to create a passkey if they don't have one
   useEffect(() => {
     if (user && browserSupport) {
-      // eslint-disable-next-line no-underscore-dangle
       if (user._count?.WebAuthnCredential === 0 && passkeyPopupDenied !== 'true') {
         setRegisterPasskeyOpen(true)
       }

--- a/src/pages/queryBuilder/textEditor/textEditorRow/AsyncAutocomplete.tsx
+++ b/src/pages/queryBuilder/textEditor/textEditorRow/AsyncAutocomplete.tsx
@@ -197,6 +197,7 @@ export function AsyncAutocomplete<T = any>({
 
   const listRef = useRef<Array<HTMLElement | null>>([])
   const listContentRef = useRef<Array<string | null>>([])
+  // eslint-disable-next-line no-undef
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
 
   const { refs, floatingStyles, context } = useFloating({

--- a/src/pages/queryBuilder/textEditor/textEditorRow/NodeSelector.tsx
+++ b/src/pages/queryBuilder/textEditor/textEditorRow/NodeSelector.tsx
@@ -93,7 +93,7 @@ export default function NodeSelector({
     includeSets = false,
   } = nodeOptions
   const { displayAlert } = useAlert()
-  // @ts-ignore: context type is not strict
+  // @ts-expect-ignore: context type is not strict
   const { concepts } = useContext(BiolinkContext) as { concepts: string[] }
 
   /**

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as CitationsRouteImport } from './routes/citations'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProfileIndexRouteImport } from './routes/profile/index'
+import { Route as GraphsIndexRouteImport } from './routes/graphs/index'
 import { Route as ExploreIndexRouteImport } from './routes/explore/index'
 import { Route as DetailsIndexRouteImport } from './routes/details/index'
 import { Route as AnswerIndexRouteImport } from './routes/answer/index'
@@ -32,11 +33,10 @@ import { Route as AdminIndexRouteImport } from './routes/admin/index'
 import { Route as ActivateUserIndexRouteImport } from './routes/activate-user/index'
 import { Route as ExploreEnrichmentAnalysisRouteImport } from './routes/explore/enrichment-analysis'
 import { Route as ShareShare_idIndexRouteImport } from './routes/share/$share_id/index'
-import { Route as ExploreGraphsIndexRouteImport } from './routes/explore/graphs/index'
+import { Route as GraphsGraph_idIndexRouteImport } from './routes/graphs/$graph_id/index'
 import { Route as ExploreDrugChemicalIndexRouteImport } from './routes/explore/drug-chemical/index'
 import { Route as DetailsDetails_idIndexRouteImport } from './routes/details/$details_id/index'
 import { Route as AnswerAnswer_idIndexRouteImport } from './routes/answer/$answer_id/index'
-import { Route as ExploreGraphsGraph_idIndexRouteImport } from './routes/explore/graphs/$graph_id/index'
 
 const WelcomeRoute = WelcomeRouteImport.update({
   id: '/welcome',
@@ -118,6 +118,11 @@ const ProfileIndexRoute = ProfileIndexRouteImport.update({
   path: '/profile/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GraphsIndexRoute = GraphsIndexRouteImport.update({
+  id: '/graphs/',
+  path: '/graphs/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ExploreIndexRoute = ExploreIndexRouteImport.update({
   id: '/explore/',
   path: '/explore/',
@@ -154,9 +159,9 @@ const ShareShare_idIndexRoute = ShareShare_idIndexRouteImport.update({
   path: '/share/$share_id/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ExploreGraphsIndexRoute = ExploreGraphsIndexRouteImport.update({
-  id: '/explore/graphs/',
-  path: '/explore/graphs/',
+const GraphsGraph_idIndexRoute = GraphsGraph_idIndexRouteImport.update({
+  id: '/graphs/$graph_id/',
+  path: '/graphs/$graph_id/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ExploreDrugChemicalIndexRoute =
@@ -175,12 +180,6 @@ const AnswerAnswer_idIndexRoute = AnswerAnswer_idIndexRouteImport.update({
   path: '/answer/$answer_id/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ExploreGraphsGraph_idIndexRoute =
-  ExploreGraphsGraph_idIndexRouteImport.update({
-    id: '/explore/graphs/$graph_id/',
-    path: '/explore/graphs/$graph_id/',
-    getParentRoute: () => rootRouteImport,
-  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -204,13 +203,13 @@ export interface FileRoutesByFullPath {
   '/answer': typeof AnswerIndexRoute
   '/details': typeof DetailsIndexRoute
   '/explore': typeof ExploreIndexRoute
+  '/graphs': typeof GraphsIndexRoute
   '/profile': typeof ProfileIndexRoute
   '/answer/$answer_id': typeof AnswerAnswer_idIndexRoute
   '/details/$details_id': typeof DetailsDetails_idIndexRoute
   '/explore/drug-chemical': typeof ExploreDrugChemicalIndexRoute
-  '/explore/graphs': typeof ExploreGraphsIndexRoute
+  '/graphs/$graph_id': typeof GraphsGraph_idIndexRoute
   '/share/$share_id': typeof ShareShare_idIndexRoute
-  '/explore/graphs/$graph_id': typeof ExploreGraphsGraph_idIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -234,13 +233,13 @@ export interface FileRoutesByTo {
   '/answer': typeof AnswerIndexRoute
   '/details': typeof DetailsIndexRoute
   '/explore': typeof ExploreIndexRoute
+  '/graphs': typeof GraphsIndexRoute
   '/profile': typeof ProfileIndexRoute
   '/answer/$answer_id': typeof AnswerAnswer_idIndexRoute
   '/details/$details_id': typeof DetailsDetails_idIndexRoute
   '/explore/drug-chemical': typeof ExploreDrugChemicalIndexRoute
-  '/explore/graphs': typeof ExploreGraphsIndexRoute
+  '/graphs/$graph_id': typeof GraphsGraph_idIndexRoute
   '/share/$share_id': typeof ShareShare_idIndexRoute
-  '/explore/graphs/$graph_id': typeof ExploreGraphsGraph_idIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -265,13 +264,13 @@ export interface FileRoutesById {
   '/answer/': typeof AnswerIndexRoute
   '/details/': typeof DetailsIndexRoute
   '/explore/': typeof ExploreIndexRoute
+  '/graphs/': typeof GraphsIndexRoute
   '/profile/': typeof ProfileIndexRoute
   '/answer/$answer_id/': typeof AnswerAnswer_idIndexRoute
   '/details/$details_id/': typeof DetailsDetails_idIndexRoute
   '/explore/drug-chemical/': typeof ExploreDrugChemicalIndexRoute
-  '/explore/graphs/': typeof ExploreGraphsIndexRoute
+  '/graphs/$graph_id/': typeof GraphsGraph_idIndexRoute
   '/share/$share_id/': typeof ShareShare_idIndexRoute
-  '/explore/graphs/$graph_id/': typeof ExploreGraphsGraph_idIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -297,13 +296,13 @@ export interface FileRouteTypes {
     | '/answer'
     | '/details'
     | '/explore'
+    | '/graphs'
     | '/profile'
     | '/answer/$answer_id'
     | '/details/$details_id'
     | '/explore/drug-chemical'
-    | '/explore/graphs'
+    | '/graphs/$graph_id'
     | '/share/$share_id'
-    | '/explore/graphs/$graph_id'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -327,13 +326,13 @@ export interface FileRouteTypes {
     | '/answer'
     | '/details'
     | '/explore'
+    | '/graphs'
     | '/profile'
     | '/answer/$answer_id'
     | '/details/$details_id'
     | '/explore/drug-chemical'
-    | '/explore/graphs'
+    | '/graphs/$graph_id'
     | '/share/$share_id'
-    | '/explore/graphs/$graph_id'
   id:
     | '__root__'
     | '/'
@@ -357,13 +356,13 @@ export interface FileRouteTypes {
     | '/answer/'
     | '/details/'
     | '/explore/'
+    | '/graphs/'
     | '/profile/'
     | '/answer/$answer_id/'
     | '/details/$details_id/'
     | '/explore/drug-chemical/'
-    | '/explore/graphs/'
+    | '/graphs/$graph_id/'
     | '/share/$share_id/'
-    | '/explore/graphs/$graph_id/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -388,13 +387,13 @@ export interface RootRouteChildren {
   AnswerIndexRoute: typeof AnswerIndexRoute
   DetailsIndexRoute: typeof DetailsIndexRoute
   ExploreIndexRoute: typeof ExploreIndexRoute
+  GraphsIndexRoute: typeof GraphsIndexRoute
   ProfileIndexRoute: typeof ProfileIndexRoute
   AnswerAnswer_idIndexRoute: typeof AnswerAnswer_idIndexRoute
   DetailsDetails_idIndexRoute: typeof DetailsDetails_idIndexRoute
   ExploreDrugChemicalIndexRoute: typeof ExploreDrugChemicalIndexRoute
-  ExploreGraphsIndexRoute: typeof ExploreGraphsIndexRoute
+  GraphsGraph_idIndexRoute: typeof GraphsGraph_idIndexRoute
   ShareShare_idIndexRoute: typeof ShareShare_idIndexRoute
-  ExploreGraphsGraph_idIndexRoute: typeof ExploreGraphsGraph_idIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -511,6 +510,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProfileIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/graphs/': {
+      id: '/graphs/'
+      path: '/graphs'
+      fullPath: '/graphs'
+      preLoaderRoute: typeof GraphsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/explore/': {
       id: '/explore/'
       path: '/explore'
@@ -560,11 +566,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ShareShare_idIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/explore/graphs/': {
-      id: '/explore/graphs/'
-      path: '/explore/graphs'
-      fullPath: '/explore/graphs'
-      preLoaderRoute: typeof ExploreGraphsIndexRouteImport
+    '/graphs/$graph_id/': {
+      id: '/graphs/$graph_id/'
+      path: '/graphs/$graph_id'
+      fullPath: '/graphs/$graph_id'
+      preLoaderRoute: typeof GraphsGraph_idIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/explore/drug-chemical/': {
@@ -586,13 +592,6 @@ declare module '@tanstack/react-router' {
       path: '/answer/$answer_id'
       fullPath: '/answer/$answer_id'
       preLoaderRoute: typeof AnswerAnswer_idIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/explore/graphs/$graph_id/': {
-      id: '/explore/graphs/$graph_id/'
-      path: '/explore/graphs/$graph_id'
-      fullPath: '/explore/graphs/$graph_id'
-      preLoaderRoute: typeof ExploreGraphsGraph_idIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
@@ -620,13 +619,13 @@ const rootRouteChildren: RootRouteChildren = {
   AnswerIndexRoute: AnswerIndexRoute,
   DetailsIndexRoute: DetailsIndexRoute,
   ExploreIndexRoute: ExploreIndexRoute,
+  GraphsIndexRoute: GraphsIndexRoute,
   ProfileIndexRoute: ProfileIndexRoute,
   AnswerAnswer_idIndexRoute: AnswerAnswer_idIndexRoute,
   DetailsDetails_idIndexRoute: DetailsDetails_idIndexRoute,
   ExploreDrugChemicalIndexRoute: ExploreDrugChemicalIndexRoute,
-  ExploreGraphsIndexRoute: ExploreGraphsIndexRoute,
+  GraphsGraph_idIndexRoute: GraphsGraph_idIndexRoute,
   ShareShare_idIndexRoute: ShareShare_idIndexRoute,
-  ExploreGraphsGraph_idIndexRoute: ExploreGraphsGraph_idIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -37,6 +37,7 @@ import { Route as GraphsGraph_idIndexRouteImport } from './routes/graphs/$graph_
 import { Route as ExploreDrugChemicalIndexRouteImport } from './routes/explore/drug-chemical/index'
 import { Route as DetailsDetails_idIndexRouteImport } from './routes/details/$details_id/index'
 import { Route as AnswerAnswer_idIndexRouteImport } from './routes/answer/$answer_id/index'
+import { Route as GraphsGraph_idGraph_versionIndexRouteImport } from './routes/graphs/$graph_id/$graph_version/index'
 
 const WelcomeRoute = WelcomeRouteImport.update({
   id: '/welcome',
@@ -180,6 +181,12 @@ const AnswerAnswer_idIndexRoute = AnswerAnswer_idIndexRouteImport.update({
   path: '/answer/$answer_id/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GraphsGraph_idGraph_versionIndexRoute =
+  GraphsGraph_idGraph_versionIndexRouteImport.update({
+    id: '/graphs/$graph_id/$graph_version/',
+    path: '/graphs/$graph_id/$graph_version/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -210,6 +217,7 @@ export interface FileRoutesByFullPath {
   '/explore/drug-chemical': typeof ExploreDrugChemicalIndexRoute
   '/graphs/$graph_id': typeof GraphsGraph_idIndexRoute
   '/share/$share_id': typeof ShareShare_idIndexRoute
+  '/graphs/$graph_id/$graph_version': typeof GraphsGraph_idGraph_versionIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -240,6 +248,7 @@ export interface FileRoutesByTo {
   '/explore/drug-chemical': typeof ExploreDrugChemicalIndexRoute
   '/graphs/$graph_id': typeof GraphsGraph_idIndexRoute
   '/share/$share_id': typeof ShareShare_idIndexRoute
+  '/graphs/$graph_id/$graph_version': typeof GraphsGraph_idGraph_versionIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -271,6 +280,7 @@ export interface FileRoutesById {
   '/explore/drug-chemical/': typeof ExploreDrugChemicalIndexRoute
   '/graphs/$graph_id/': typeof GraphsGraph_idIndexRoute
   '/share/$share_id/': typeof ShareShare_idIndexRoute
+  '/graphs/$graph_id/$graph_version/': typeof GraphsGraph_idGraph_versionIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -303,6 +313,7 @@ export interface FileRouteTypes {
     | '/explore/drug-chemical'
     | '/graphs/$graph_id'
     | '/share/$share_id'
+    | '/graphs/$graph_id/$graph_version'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -333,6 +344,7 @@ export interface FileRouteTypes {
     | '/explore/drug-chemical'
     | '/graphs/$graph_id'
     | '/share/$share_id'
+    | '/graphs/$graph_id/$graph_version'
   id:
     | '__root__'
     | '/'
@@ -363,6 +375,7 @@ export interface FileRouteTypes {
     | '/explore/drug-chemical/'
     | '/graphs/$graph_id/'
     | '/share/$share_id/'
+    | '/graphs/$graph_id/$graph_version/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -394,6 +407,7 @@ export interface RootRouteChildren {
   ExploreDrugChemicalIndexRoute: typeof ExploreDrugChemicalIndexRoute
   GraphsGraph_idIndexRoute: typeof GraphsGraph_idIndexRoute
   ShareShare_idIndexRoute: typeof ShareShare_idIndexRoute
+  GraphsGraph_idGraph_versionIndexRoute: typeof GraphsGraph_idGraph_versionIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -594,6 +608,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AnswerAnswer_idIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/graphs/$graph_id/$graph_version/': {
+      id: '/graphs/$graph_id/$graph_version/'
+      path: '/graphs/$graph_id/$graph_version'
+      fullPath: '/graphs/$graph_id/$graph_version'
+      preLoaderRoute: typeof GraphsGraph_idGraph_versionIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -626,6 +647,7 @@ const rootRouteChildren: RootRouteChildren = {
   ExploreDrugChemicalIndexRoute: ExploreDrugChemicalIndexRoute,
   GraphsGraph_idIndexRoute: GraphsGraph_idIndexRoute,
   ShareShare_idIndexRoute: ShareShare_idIndexRoute,
+  GraphsGraph_idGraph_versionIndexRoute: GraphsGraph_idGraph_versionIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/graphs/$graph_id/$graph_version/index.tsx
+++ b/src/routes/graphs/$graph_id/$graph_version/index.tsx
@@ -1,0 +1,76 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { queryClient } from '../../../../utils/queryClient'
+import { graphMetadata, graphSchema } from '../../../../API/graphRegistry'
+import { useQuery } from '@tanstack/react-query'
+import GraphId from '../../../../pages/graphId/GraphId'
+
+// export const Route = createFileRoute('/graphs/$graph_id/$graph_version/')({
+//   component: RouteComponent,
+// })
+export const Route = createFileRoute('/graphs/$graph_id/$graph_version/')({
+  component: RouteComponent,
+  ssr: false,
+  loader: async ({ params }) => {
+    const [v2Metadata, schemaV2] = await Promise.all([
+      queryClient.ensureQueryData({
+        queryKey: ['graph-metadata', params.graph_id, params.graph_version],
+        queryFn: () => graphMetadata(params.graph_id!, params.graph_version!),
+      }),
+      queryClient.ensureQueryData({
+        queryKey: ['graph-schema', params.graph_id, params.graph_version],
+        queryFn: () => graphSchema(params.graph_id!, params.graph_version!),
+      }),
+    ])
+
+    return {
+      v2Metadata,
+      schemaV2,
+    }
+  },
+  head: ({ loaderData, params }) => {
+    const cachedData: any = queryClient.getQueryData([
+      'graph-metadata',
+      params.graph_id,
+      params.graph_version,
+    ])
+    const cachedMetadataV2: any =
+      loaderData?.v2Metadata ??
+      queryClient.getQueryData(['graph-metadata', params.graph_id, params.graph_version])
+
+    return {
+      meta: [
+        {
+          title: cachedData ? `${cachedData.name} | ROBOKOP` : 'Graph | ROBOKOP',
+        },
+      ],
+      scripts: cachedMetadataV2
+        ? [
+            {
+              type: 'application/ld+json',
+              children: JSON.stringify(cachedMetadataV2),
+            },
+          ]
+        : [],
+    }
+  },
+})
+
+function RouteComponent() {
+  const { graph_id, graph_version } = Route.useParams()
+
+  const { data: v2Metadata, isPending: v2Pending } = useQuery({
+    queryKey: ['graph-metadata', graph_id, graph_version],
+    queryFn: () => graphMetadata(graph_id!, graph_version!),
+    enabled: !!graph_id,
+  })
+
+  const { data: schemaV2, isPending: schemaPending } = useQuery({
+    queryKey: ['graph-schema', graph_id, graph_version],
+    queryFn: () => graphSchema(graph_id!, graph_version!),
+    enabled: !!graph_id,
+  })
+
+  if (v2Pending || schemaPending) return 'Loading...'
+
+  return <GraphId v2Metadata={v2Metadata ?? null} schemaV2={schemaV2 ?? null} />
+}

--- a/src/routes/graphs/$graph_id/index.tsx
+++ b/src/routes/graphs/$graph_id/index.tsx
@@ -1,68 +1,87 @@
-import { createFileRoute } from '@tanstack/react-router'
-import API from '../../../API'
-import { queryClient } from '../../../utils/queryClient'
-import { useQuery } from '@tanstack/react-query'
-import GraphId from '../../../pages/graphId/GraphId'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/graphs/$graph_id/')({
+  beforeLoad: ({ params }) => {
+    throw redirect({
+      to: '/graphs/$graph_id/$graph_version',
+      params: {
+        graph_id: params.graph_id,
+        graph_version: 'latest',
+      },
+    })
+  },
   component: RouteComponent,
-  ssr: false,
-  loader: async ({ params }) => {
-    const [v2Metadata, schemaV2] = await Promise.all([
-      queryClient.ensureQueryData({
-        queryKey: ['graph-metadata-v2', params.graph_id],
-        queryFn: () => API.graphMetadata.graphMetadataV2(params.graph_id),
-      }),
-      queryClient.ensureQueryData({
-        queryKey: ['graph-schema-v2', params.graph_id],
-        queryFn: () => API.graphMetadata.graphSchemaV2(params.graph_id!),
-      }),
-    ])
-
-    return {
-      v2Metadata,
-      schemaV2,
-    }
-  },
-  head: ({ loaderData, params }) => {
-    const cachedData: any = queryClient.getQueryData(['graph-metadata', params.graph_id])
-    const cachedMetadataV2: any =
-      loaderData?.v2Metadata ?? queryClient.getQueryData(['graph-metadata-v2', params.graph_id])
-
-    return {
-      meta: [
-        {
-          title: cachedData ? `${cachedData.graph_name} | ROBOKOP` : 'Graph | ROBOKOP',
-        },
-      ],
-      scripts: cachedMetadataV2
-        ? [
-            {
-              type: 'application/ld+json',
-              children: JSON.stringify(cachedMetadataV2),
-            },
-          ]
-        : [],
-    }
-  },
 })
 
 function RouteComponent() {
-  const { graph_id } = Route.useParams()
-
-  const { data: v2Metadata, isPending: v2Pending } = useQuery({
-    queryKey: ['graph-metadata-v2', graph_id],
-    queryFn: () => API.graphMetadata.graphMetadataV2(graph_id!),
-    enabled: !!graph_id,
-  })
-
-  const { data: schemaV2, isPending: schemaPending } = useQuery({
-    queryKey: ['graph-schema-v2', graph_id],
-    queryFn: () => API.graphMetadata.graphSchemaV2(graph_id!),
-    enabled: !!graph_id,
-  })
-
-  if (v2Pending || schemaPending) return 'Loading...'
-
-  return <GraphId v2Metadata={v2Metadata ?? null} schemaV2={schemaV2 ?? null} />
+  return <div>Redirecting...</div>
 }
+
+// import { createFileRoute } from '@tanstack/react-router'
+// import API from '../../../API'
+// import { queryClient } from '../../../utils/queryClient'
+// import { useQuery } from '@tanstack/react-query'
+// import GraphId from '../../../pages/graphId/GraphId'
+
+// export const Route = createFileRoute('/graphs/$graph_id/')({
+//   component: RouteComponent,
+//   ssr: false,
+//   loader: async ({ params }) => {
+//     const [v2Metadata, schemaV2] = await Promise.all([
+//       queryClient.ensureQueryData({
+//         queryKey: ['graph-metadata-v2', params.graph_id],
+//         queryFn: () => API.graphMetadata.graphMetadataV2(params.graph_id),
+//       }),
+//       queryClient.ensureQueryData({
+//         queryKey: ['graph-schema-v2', params.graph_id],
+//         queryFn: () => API.graphMetadata.graphSchemaV2(params.graph_id!),
+//       }),
+//     ])
+
+//     return {
+//       v2Metadata,
+//       schemaV2,
+//     }
+//   },
+//   head: ({ loaderData, params }) => {
+//     const cachedData: any = queryClient.getQueryData(['graph-metadata', params.graph_id])
+//     const cachedMetadataV2: any =
+//       loaderData?.v2Metadata ?? queryClient.getQueryData(['graph-metadata-v2', params.graph_id])
+
+//     return {
+//       meta: [
+//         {
+//           title: cachedData ? `${cachedData.graph_name} | ROBOKOP` : 'Graph | ROBOKOP',
+//         },
+//       ],
+//       scripts: cachedMetadataV2
+//         ? [
+//             {
+//               type: 'application/ld+json',
+//               children: JSON.stringify(cachedMetadataV2),
+//             },
+//           ]
+//         : [],
+//     }
+//   },
+// })
+
+// function RouteComponent() {
+//   const { graph_id } = Route.useParams()
+
+//   const { data: v2Metadata, isPending: v2Pending } = useQuery({
+//     queryKey: ['graph-metadata-v2', graph_id],
+//     queryFn: () => API.graphMetadata.graphMetadataV2(graph_id!),
+//     enabled: !!graph_id,
+//   })
+
+//   const { data: schemaV2, isPending: schemaPending } = useQuery({
+//     queryKey: ['graph-schema-v2', graph_id],
+//     queryFn: () => API.graphMetadata.graphSchemaV2(graph_id!),
+//     enabled: !!graph_id,
+//   })
+
+//   if (v2Pending || schemaPending) return 'Loading...'
+
+//   return <GraphId v2Metadata={v2Metadata ?? null} schemaV2={schemaV2 ?? null} />
+// }

--- a/src/routes/graphs/$graph_id/index.tsx
+++ b/src/routes/graphs/$graph_id/index.tsx
@@ -1,10 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
-import API from '../../../../API'
-import { queryClient } from '../../../../utils/queryClient'
+import API from '../../../API'
+import { queryClient } from '../../../utils/queryClient'
 import { useQuery } from '@tanstack/react-query'
-import GraphId from '../../../../pages/graphId/GraphId'
+import GraphId from '../../../pages/graphId/GraphId'
 
-export const Route = createFileRoute('/explore/graphs/$graph_id/')({
+export const Route = createFileRoute('/graphs/$graph_id/')({
   component: RouteComponent,
   ssr: false,
   loader: async ({ params }) => {

--- a/src/routes/graphs/index.tsx
+++ b/src/routes/graphs/index.tsx
@@ -1,10 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
-import API from '../../../API'
-import { queryClient } from '../../../utils/queryClient'
+import API from '../../API'
+import { queryClient } from '../../utils/queryClient'
 import { useQuery } from '@tanstack/react-query'
-import Graph from '../../../pages/graph/Graph'
+import Graph from '../../pages/graph/Graph'
 
-export const Route = createFileRoute('/explore/graphs/')({
+export const Route = createFileRoute('/graphs/')({
   component: RouteComponent,
   head: () => ({
     meta: [{ title: 'Graphs | ROBOKOP' }],
@@ -12,26 +12,6 @@ export const Route = createFileRoute('/explore/graphs/')({
 })
 
 function RouteComponent() {
-  // const { isLoading, data: graphData } = useQuery({
-  //   queryKey: ["graphs"],
-  //   queryFn: async () => {
-  //     const registry = await API.graphMetadata.registry();
-
-  //     if (!Array.isArray(registry)) {
-  //       throw new Error(registry.message || "Failed to fetch graph registry");
-  //     }
-
-  //     const graphData = await Promise.all(registry.map((graphId) => API.graphMetadata.metadata(graphId).then((data) => ({ ...data, graph_id: graphId }))));
-
-  //     const sortedGraphData = graphData.sort((a, b) => b.final_node_count - a.final_node_count);
-  //     console.log(sortedGraphData, "sortedGraphData in graph list");
-  //     for (const graph of sortedGraphData) {
-  //       queryClient.setQueryData(["graph-metadata", graph.graph_id], graph);
-  //     }
-  //     return sortedGraphData;
-  //   },
-  // });
-
   const { isLoading: isLoadingV2, data: graphDataV2 } = useQuery({
     queryKey: ['graphsV2'],
     queryFn: async () => {

--- a/src/routes/graphs/index.tsx
+++ b/src/routes/graphs/index.tsx
@@ -17,7 +17,7 @@ function RouteComponent() {
     queryKey: ['graph-registry'],
     queryFn: async () => {
       const registry = await graphRegistryList()
-      const sortedGraphData = registry.sort((a, b) => b.node_count - a.node_count)
+      const sortedGraphData = registry.sort((a, b) => b.nodes_count - a.nodes_count)
       return sortedGraphData
     },
   })

--- a/src/routes/graphs/index.tsx
+++ b/src/routes/graphs/index.tsx
@@ -3,6 +3,7 @@ import API from '../../API'
 import { queryClient } from '../../utils/queryClient'
 import { useQuery } from '@tanstack/react-query'
 import Graph from '../../pages/graph/Graph'
+import { graphRegistryList } from '../../API/graphRegistry'
 
 export const Route = createFileRoute('/graphs/')({
   component: RouteComponent,
@@ -13,44 +14,13 @@ export const Route = createFileRoute('/graphs/')({
 
 function RouteComponent() {
   const { isLoading: isLoadingV2, data: graphDataV2 } = useQuery({
-    queryKey: ['graphsV2'],
+    queryKey: ['graph-registry'],
     queryFn: async () => {
-      const registry = await API.graphMetadata.registry()
-
-      if (!Array.isArray(registry)) {
-        throw new Error(registry.message || 'Failed to fetch graph registry')
-      }
-
-      const graphData = await Promise.all(
-        registry.map((graphId) =>
-          API.graphMetadata.graphMetadataV2(graphId).then((data) => {
-            console.log(data, 'data in graphMetadataV2 in graph list')
-            let totalNodeCount = 0
-            let totalEdgeCount = 0
-            if (data?.hasPart && Array.isArray(data.hasPart)) {
-              data.hasPart.forEach((part) => {
-                if (part['orion:nodeCount']) {
-                  totalNodeCount += part['orion:nodeCount']
-                }
-                if (part['orion:edgeCount']) {
-                  totalEdgeCount += part['orion:edgeCount']
-                }
-              })
-            }
-            return { ...data, graph_id: graphId, totalNodeCount, totalEdgeCount }
-          }),
-        ),
-      )
-
-      const sortedGraphData = graphData.sort((a, b) => b.totalNodeCount - a.totalNodeCount)
-      console.log(sortedGraphData, 'sortedGraphData in graph list')
-      for (const graph of sortedGraphData) {
-        queryClient.setQueryData(['graph-metadata-v2', graph.graph_id], graph)
-      }
+      const registry = await graphRegistryList()
+      const sortedGraphData = registry.sort((a, b) => b.node_count - a.node_count)
       return sortedGraphData
     },
   })
-  console.log(graphDataV2, 'graphDataV2 in graph list', isLoadingV2)
 
   return <Graph graphData={graphDataV2!} isLoading={isLoadingV2} />
 }

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -47,7 +47,7 @@ export default function getNodeCategoryColorMap(hierarchies: Hierarchies) {
       return [null, undefinedColor]
     }
     if (!Array.isArray(categories)) {
-      categories = [categories] // eslint-disable-line
+      categories = [categories]
     }
     // traverse up hierarchy until we find a category we have a color for
     let category: Category | undefined

--- a/src/utils/d3/drag.ts
+++ b/src/utils/d3/drag.ts
@@ -129,14 +129,8 @@ function dragEdgeEnd(
       updateEdge(id, mapping[type as keyof EdgeEndMapping], (droppedCircle as any).id)
     } else {
       // edge was dropped in space, put it back to previous nodes
-      let {
-        x1,
-        y1,
-        qx,
-        qy,
-        x2,
-        y2, // eslint-disable-line prefer-const
-      } = graphUtils.getCurvedEdgePos(
+      // eslint-disable-next-line prefer-const
+      let { x1, y1, qx, qy, x2, y2 } = graphUtils.getCurvedEdgePos(
         d.source.x,
         d.source.y,
         d.target.x,

--- a/src/utils/d3/edges.ts
+++ b/src/utils/d3/edges.ts
@@ -1,4 +1,3 @@
-/* eslint-disable indent */
 import * as d3 from 'd3'
 import graphUtils from './graph'
 import dragUtils from './drag'

--- a/src/utils/d3/nodes.ts
+++ b/src/utils/d3/nodes.ts
@@ -1,4 +1,3 @@
-/* eslint-disable indent, no-use-before-define, func-names, no-return-assign */
 import * as d3 from 'd3'
 import graphUtils from './graph'
 import dragUtils from './drag'

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -1,5 +1,5 @@
 export function formatBuildDate(buildTime: string) {
-  const [datePart, timePart] = buildTime?.split(' ')
+  const [datePart, timePart] = buildTime.split(' ')
 
   if (!timePart) {
     const date = new Date(buildTime)
@@ -10,8 +10,8 @@ export function formatBuildDate(buildTime: string) {
       day: 'numeric',
     })
   } else {
-    const [month, day, year] = datePart?.split('-').map(Number)
-    const [hours, minutes, seconds] = timePart?.split(':').map(Number)
+    const [month, day, year] = datePart.split('-').map(Number)
+    const [hours, minutes, seconds] = timePart.split(':').map(Number)
 
     const fullYear = 2000 + year
 

--- a/src/utils/queryBuilder.ts
+++ b/src/utils/queryBuilder.ts
@@ -178,7 +178,7 @@ function removeAttachedEdges(q_graph: { edges: { [x: string]: any } }, nodeId: a
  * @param {object} query_graph - query graph object
  * @returns isValid boolean and an error message
  */
-function isValidGraph(query_graph: { nodes: {}; edges: any }) {
+function isValidGraph(query_graph: { nodes: object; edges: any }) {
   let isValid = true
   let errMsg = ''
   const nodeIds = Object.keys(query_graph.nodes)

--- a/src/utils/results.ts
+++ b/src/utils/results.ts
@@ -85,7 +85,7 @@ function findConnectedNodes(
  * @param {string} startingNode - node id
  * @returns {string[]} topologically sorted nodes
  */
-export function sortNodes(query_graph: { edges: any; nodes: {} }, startingNode: string) {
+export function sortNodes(query_graph: { edges: any; nodes: object }, startingNode: string) {
   const sortedNodes = [startingNode]
   findConnectedNodes(query_graph.edges, sortedNodes)
   // TODO: handle detached sub-graphs, right now those nodes will be tacked on the end in insertion order

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -68,7 +68,6 @@ function displayCategory(arg: string | string[]) {
     // split pascal case
     const splitCategory = pascalCategory.split(/(?=[A-Z][a-z])/g)
     return splitCategory.join(' ')
-    // eslint-disable-next-line no-unused-vars
   } catch (err) {
     return ''
   }
@@ -107,6 +106,7 @@ function displayPredicate(arg: string) {
   }
   try {
     // remove 'biolink:'
+    // eslint-disable-next-line no-unsafe-optional-chaining
     const [, snake_type] = label?.split(':')
     // split snake case
     const out = snake_type?.split(/_/g)


### PR DESCRIPTION
This pull request introduces a new API layer for interacting with the graph registry, updates the UI to consume this new API, and refactors the graph download and release functionality for improved consistency and maintainability. Additionally, it standardizes routes and updates several UI components to use the latest data structures and endpoints.

**API integration and data fetching:**

* Added a new `src/API/graphRegistry.ts` module that provides functions and types for interacting with the graph registry, including fetching graph lists, schemas, metadata, download options, and version lists.
* Refactored download data fetching in `DownloadSection` and `GraphId` components to use the new `getGraphDownloadList` and `getGraphVersionList` functions from the API module, replacing previous ad hoc implementations. [[1]](diffhunk://#diff-33add51b40f9840c2d637c7e6a7c4c0b571989a0bb425b72396bec5db3fe7f8cL30-L44) [[2]](diffhunk://#diff-444dd24cfaedb85cfa474b4f38c5dea23dd56fddf05d62679a5c9485f9f84d1cR24-R40) [[3]](diffhunk://#diff-444dd24cfaedb85cfa474b4f38c5dea23dd56fddf05d62679a5c9485f9f84d1cL96-L119)

**UI and UX improvements:**

* Updated the download section to display available files in a table with file name and size, using the new API data structure. The section now receives the graph version as a prop for more accurate queries. [[1]](diffhunk://#diff-33add51b40f9840c2d637c7e6a7c4c0b571989a0bb425b72396bec5db3fe7f8cL77-R154) [[2]](diffhunk://#diff-33add51b40f9840c2d637c7e6a7c4c0b571989a0bb425b72396bec5db3fe7f8cL148-R216) [[3]](diffhunk://#diff-33add51b40f9840c2d637c7e6a7c4c0b571989a0bb425b72396bec5db3fe7f8cL217-R281)
* Added a new "Releases" section in the sidebar and main view, displaying available graph versions and highlighting the latest release. [[1]](diffhunk://#diff-444dd24cfaedb85cfa474b4f38c5dea23dd56fddf05d62679a5c9485f9f84d1cR24-R40) [[2]](diffhunk://#diff-444dd24cfaedb85cfa474b4f38c5dea23dd56fddf05d62679a5c9485f9f84d1cL198-R228)
* Improved the metadata download link in the header card to use the new API and ensure correct URL formatting. [[1]](diffhunk://#diff-37b0040a1658addc8fdfe95d687d88e1c3847e855215fb300af05fd3d3575d61R43-R45) [[2]](diffhunk://#diff-37b0040a1658addc8fdfe95d687d88e1c3847e855215fb300af05fd3d3575d61L138-R148)

**Data structure and prop updates:**

* Updated `Graph.tsx` and related components to use the new `GraphRegistryEntry` type, and adjusted property references accordingly (e.g., `nodes_count`, `edges_counts`, `summary`). [[1]](diffhunk://#diff-f42bca6f6413fd805f455189ff008f7480553f046f3c9b149ff55d316f4c79dbR6-R16) [[2]](diffhunk://#diff-f42bca6f6413fd805f455189ff008f7480553f046f3c9b149ff55d316f4c79dbL65-R82)

**Route and navigation consistency:**

* Standardized routes throughout the application, changing `/explore/graphs` to `/graphs` in navigation, breadcrumbs, and detail links for consistency. [[1]](diffhunk://#diff-89357286fd8826f48f856126e7178e54f3319ba37ba7f5365417d8b375d939afL131-R131) [[2]](diffhunk://#diff-f42bca6f6413fd805f455189ff008f7480553f046f3c9b149ff55d316f4c79dbL92-R96) [[3]](diffhunk://#diff-4b4c04ad4370e256405ba53cec494cc9d96b0a604f045dd4d898e1ac1d3ec5a5L9-R9)

**Miscellaneous:**

* Cleaned up unused imports and legacy code related to previous download and metadata fetching implementations. [[1]](diffhunk://#diff-444dd24cfaedb85cfa474b4f38c5dea23dd56fddf05d62679a5c9485f9f84d1cL8-L15) [[2]](diffhunk://#diff-37b0040a1658addc8fdfe95d687d88e1c3847e855215fb300af05fd3d3575d61L6-R6)

These changes modernize the graph registry integration, improve maintainability, and provide a more consistent user experience.