### PR TITLE
Fixed node and edge count

### DIFF
--- a/src/pages/graphId/GraphId.tsx
+++ b/src/pages/graphId/GraphId.tsx
@@ -171,6 +171,8 @@ function GraphId({ v2Metadata, schemaV2 }: GraphIdV2Props) {
           setIsSankeyGraphModalOpen={setIsSankeyGraphModalOpen}
           graph_id={graph_id}
           downloadLink={validDownloadLink}
+          nodeCount={schemaV2?.schema.nodes_summary.total_count || 0}
+          edgeCount={schemaV2?.schema.edges_summary.total_count || 0}
         />
 
         <Grid size={8} sx={{ mt: 2 }}>

--- a/src/pages/graphId/HeaderCard.tsx
+++ b/src/pages/graphId/HeaderCard.tsx
@@ -15,6 +15,8 @@ interface HeaderCardProps {
   setIsSankeyGraphModalOpen: (isOpen: boolean) => void
   graph_id: string | undefined
   downloadLink: string
+  nodeCount: number
+  edgeCount: number
 }
 
 function HeaderCard({
@@ -27,19 +29,9 @@ function HeaderCard({
   setIsSankeyGraphModalOpen,
   graph_id,
   downloadLink,
+  nodeCount,
+  edgeCount,
 }: HeaderCardProps) {
-  let totalNodeCount = 0
-  let totalEdgeCount = 0
-  if (v2Metadata?.hasPart && Array.isArray(v2Metadata.hasPart)) {
-    v2Metadata.hasPart.forEach((part) => {
-      if (part['orion:nodeCount']) {
-        totalNodeCount += part['orion:nodeCount']
-      }
-      if (part['orion:edgeCount']) {
-        totalEdgeCount += part['orion:edgeCount']
-      }
-    })
-  }
   const metadataHref = latestMetadataUrl
     ? `${window.location.origin}/graphs/${latestMetadataUrl.replace(/^\/+/, '')}`
     : undefined
@@ -72,13 +64,13 @@ function HeaderCard({
           </Box>
           <Stack direction='row' spacing={1} flexWrap='wrap' useFlexGap>
             <Chip
-              label={`${stringUtils.formatNumber(totalNodeCount)} nodes`}
+              label={`${stringUtils.formatNumber(nodeCount)} nodes`}
               size='small'
               color='default'
               variant='outlined'
             />
             <Chip
-              label={`${stringUtils.formatNumber(totalEdgeCount)} edges`}
+              label={`${stringUtils.formatNumber(edgeCount)} edges`}
               size='small'
               color='default'
               variant='outlined'


### PR DESCRIPTION
This pull request refactors how node and edge counts are handled and displayed in the graph details page. Instead of calculating these counts in the `HeaderCard` component, the counts are now passed as props, making the code cleaner and more efficient.

**Refactoring and Propagation of Node and Edge Counts:**

* The `HeaderCard` component's props now include `nodeCount` and `edgeCount`, which are passed in directly instead of being computed inside the component.
* The logic to sum node and edge counts from `v2Metadata.hasPart` has been removed from `HeaderCard`, simplifying the component.
* The display of node and edge counts in `HeaderCard` now uses the new props, ensuring consistency and reducing duplication.
* The parent `GraphId` component is updated to extract `nodeCount` and `edgeCount` from `schemaV2` and pass them to `HeaderCard`.