### PR TITLE
fixed graph releases

### DIFF
--- a/src/API/graphRegistry.ts
+++ b/src/API/graphRegistry.ts
@@ -15,6 +15,12 @@ export interface GraphDownloadData {
   file_size_bytes: number
 }
 
+export interface ReleasesData {
+  latest: boolean
+  release_date: string
+  version: string
+}
+
 export const graphRegistryList = async (): Promise<GraphRegistryEntry[]> => {
   const response = await axios.get(`${GRAPH_REGISTRY_ROUTE}/registry`)
   if (response.status === 200) {
@@ -56,7 +62,7 @@ export const getGraphDownloadList = async (
   }
 }
 
-export const getGraphVersionList = async (graph_id: string): Promise<string[]> => {
+export const getGraphVersionList = async (graph_id: string): Promise<ReleasesData[]> => {
   const response = await axios.get(`${GRAPH_REGISTRY_ROUTE}/versions/${graph_id}`)
   if (response.status === 200) {
     return response.data

--- a/src/pages/graphId/GraphId.tsx
+++ b/src/pages/graphId/GraphId.tsx
@@ -122,13 +122,6 @@ function GraphId({ v2Metadata, schemaV2 }: GraphIdV2Props) {
     queryFn: () => getGraphVersionList(graph_id!),
     enabled: !!graph_id,
   })
-  const isLatestInReleaseData = releaseData?.find((v) => v === 'latest') !== undefined
-  const { data: schemaV2Latest } = useQuery({
-    queryKey: ['graph-metadata', graph_id, 'latest'],
-    queryFn: () => graphMetadata(graph_id!, 'latest'),
-    enabled: isLatestInReleaseData,
-  })
-  const latestVersionID = schemaV2Latest?.version
 
   const graphDatasetV2 = React.useMemo(() => {
     return schemaV2 ? transformSchemaToLinks(schemaV2) : { nodes: [], links: [] }
@@ -221,11 +214,7 @@ function GraphId({ v2Metadata, schemaV2 }: GraphIdV2Props) {
         </Grid>
       </Box>
       <Box>
-        <Releases
-          latestVersion={latestVersionID}
-          releases={releaseData}
-          loading={isReleaseDataLoading}
-        />
+        <Releases releases={releaseData} loading={isReleaseDataLoading} />
         <DownloadSection version={displayVersion} />
       </Box>
     </Container>

--- a/src/pages/graphId/Releases.tsx
+++ b/src/pages/graphId/Releases.tsx
@@ -18,25 +18,16 @@ import {
   Typography,
 } from '@mui/material'
 import { OpenInNew as OpenInNewIcon, Update as UpdateIcon } from '@mui/icons-material'
+import { ReleasesData } from '../../API/graphRegistry'
 
 export interface ReleasesProps {
-  latestVersion?: string
-  releases?: string[]
+  releases?: ReleasesData[]
   loading?: boolean
 }
 
-function Releases({ latestVersion, releases, loading }: ReleasesProps) {
+function Releases({ releases, loading }: ReleasesProps) {
+  console.log('releases', { releases, loading })
   const { graph_id, graph_version } = useParams({ strict: false })
-
-  const formatVersionList = (versionList: string[], latestVersion: string | undefined) => {
-    return versionList
-      .filter((entry) => entry !== 'latest')
-      .map((entry) => ({
-        version: entry,
-        latest: entry === latestVersion,
-      }))
-  }
-  const formattedReleases = formatVersionList(releases || [], latestVersion)
 
   const isViewingVersion = (version: string, isLatest: boolean) => {
     if (!graph_version) return false
@@ -82,7 +73,7 @@ function Releases({ latestVersion, releases, loading }: ReleasesProps) {
         <CardContent>
           {loading ? (
             renderSkeleton()
-          ) : formattedReleases.length > 0 ? (
+          ) : releases && releases.length > 0 ? (
             <TableContainer>
               <Table size='small'>
                 <TableHead>
@@ -92,10 +83,15 @@ function Releases({ latestVersion, releases, loading }: ReleasesProps) {
                         Version
                       </Typography>
                     </TableCell>
+                    <TableCell align='right'>
+                      <Typography variant='subtitle2' fontWeight='bold'>
+                        Date
+                      </Typography>
+                    </TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {formattedReleases.map((release) => {
+                  {releases?.map((release) => {
                     const isActiveVersion = isViewingVersion(release.version, release.latest)
 
                     return (
@@ -134,6 +130,11 @@ function Releases({ latestVersion, releases, loading }: ReleasesProps) {
                               />
                             ) : null}
                           </Link>
+                        </TableCell>
+                        <TableCell align='right'>
+                          <Typography variant='body2' color='text.secondary'>
+                            {new Date(release.release_date).toLocaleDateString()}
+                          </Typography>
                         </TableCell>
                       </TableRow>
                     )


### PR DESCRIPTION
This pull request updates the handling and display of graph release versions to provide richer metadata and a more informative user interface. The main changes involve switching from a simple list of version strings to a structured `ReleasesData` object, updating API calls and UI components accordingly, and enhancing the releases table to show release dates.

**API and Data Structure Updates:**

* Introduced a new `ReleasesData` interface in `graphRegistry.ts` to represent release metadata, including `latest`, `release_date`, and `version` fields. The `getGraphVersionList` API now returns an array of `ReleasesData` instead of strings. [[1]](diffhunk://#diff-2992bbe167085f8c1416c285dd0b97fd02adefaec47d074beb27df46ebd7dbccR18-R23) [[2]](diffhunk://#diff-2992bbe167085f8c1416c285dd0b97fd02adefaec47d074beb27df46ebd7dbccL59-R65)

**UI and Component Updates:**

* Refactored the `Releases` component and its usage to accept and display the new `ReleasesData` structure, removing the need to separately determine the latest version and simplifying props. [[1]](diffhunk://#diff-9ded4f59fdb616e0da9788f36a44edc336db5ccbb6426a9c2940e65fe67315dcR21-L40) [[2]](diffhunk://#diff-444dd24cfaedb85cfa474b4f38c5dea23dd56fddf05d62679a5c9485f9f84d1cL224-R217)
* Enhanced the releases table UI to display the release date for each version, using the new `release_date` field. [[1]](diffhunk://#diff-9ded4f59fdb616e0da9788f36a44edc336db5ccbb6426a9c2940e65fe67315dcR86-R94) [[2]](diffhunk://#diff-9ded4f59fdb616e0da9788f36a44edc336db5ccbb6426a9c2940e65fe67315dcR134-R138)
* Removed legacy logic for handling the 'latest' version and related queries in `GraphId.tsx`, as this is now handled via the structured release data.
* Updated conditional rendering logic in the `Releases` component to work with the new data structure.