### PR TITLE
Name change for robokop graphs

### DIFF
--- a/src/pages/graph/Graph.tsx
+++ b/src/pages/graph/Graph.tsx
@@ -22,7 +22,7 @@ function Graph({ graphData, isLoading }: GraphProps) {
       }}
     >
       <Typography variant='h4' component='h1' mb={1} sx={{ fontWeight: 500, textAlign: 'center' }}>
-        ROBOKOP Graphs
+        ROBOKOP Atlas
       </Typography>
       <Typography
         variant='body1'

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -29,7 +29,7 @@ export default function LandingPage() {
             tool to explore relevant publications.
           </p>
         </Card>
-        <Card title='Graph Registry' href='/graphs' icon={<DataIcon />} gradient='purple'>
+        <Card title='ROBOKOP Atlas' href='/graphs' icon={<DataIcon />} gradient='purple'>
           <p>Learn about the data in ROBOKOP and explore knowledge graph using our data browser.</p>
         </Card>
       </CardContainer>


### PR DESCRIPTION
This pull request updates the branding of the application to use "ROBOKOP Atlas" instead of "ROBOKOP Graphs" in key UI elements. The main changes are:

UI Text and Branding Updates:

* Changed the main heading in the `Graph` page from "ROBOKOP Graphs" to "ROBOKOP Atlas" to reflect the new branding. (`src/pages/graph/Graph.tsx`)
* Updated the title of the "Graph Registry" card on the landing page to "ROBOKOP Atlas" for consistency with the new branding. (`src/pages/landing/index.tsx`)

Fixes RobokopU24/Feedback#288