### PR TITLE
Fixed footer formatting bug, closes RobokopU24/Feedback#283

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import { Link } from '@tanstack/react-router'
+import { formatBuildDate } from '../../utils/dateTime'
 import './footer.css'
 
-const version = import.meta.env.VITE_APP_VERSION
-const buildDate = import.meta.env.VITE_BUILD_DATE
+const rawVersion = import.meta.env.VITE_APP_VERSION as string | undefined
+const version = rawVersion?.replace(/^v/i, '')
+const buildDate = import.meta.env.VITE_BUILD_DATE as string | undefined
+const formattedBuildDate = buildDate ? formatBuildDate(buildDate) : undefined
 
 export default function Footer() {
   return (
@@ -34,11 +37,11 @@ export default function Footer() {
         </a>
         . <Link to='/termsofservice'>Terms of Service</Link>.
       </p>
-      {(version || buildDate) && (
+      {(version || formattedBuildDate) && (
         <p className='footer-version'>
           {version && <>v{version}</>}
-          {version && buildDate && ' | '}
-          {buildDate && <>Deployed: {buildDate}</>}
+          {version && formattedBuildDate && ' | '}
+          {formattedBuildDate && <>Deployed: {formattedBuildDate}</>}
         </p>
       )}
     </footer>


### PR DESCRIPTION
This pull request updates the `Footer` component to improve the display of version and build date information. The main change is the introduction of formatted build dates for better readability.

**Footer display improvements:**

* [`src/components/footer/Footer.tsx`](diffhunk://#diff-c096857ee8ce97499b45a56c3d9bc8d9cc0e0a9c25ce378eb10a235a7dddf900R3-R9): Now uses a new `formatBuildDate` utility to display the build date in a more user-friendly format, and strips any leading "v" from the version string for consistency. [[1]](diffhunk://#diff-c096857ee8ce97499b45a56c3d9bc8d9cc0e0a9c25ce378eb10a235a7dddf900R3-R9) [[2]](diffhunk://#diff-c096857ee8ce97499b45a56c3d9bc8d9cc0e0a9c25ce378eb10a235a7dddf900L37-R44)