### PR TITLE
Rename Robokop graphs and fix footer formatting

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import { Link } from '@tanstack/react-router'
+import { formatBuildDate } from '../../utils/dateTime'
 import './footer.css'
 
-const version = import.meta.env.VITE_APP_VERSION
-const buildDate = import.meta.env.VITE_BUILD_DATE
+const rawVersion = import.meta.env.VITE_APP_VERSION as string | undefined
+const version = rawVersion?.replace(/^v/i, '')
+const buildDate = import.meta.env.VITE_BUILD_DATE as string | undefined
+const formattedBuildDate = buildDate ? formatBuildDate(buildDate) : undefined
 
 export default function Footer() {
   return (
@@ -34,11 +37,11 @@ export default function Footer() {
         </a>
         . <Link to='/termsofservice'>Terms of Service</Link>.
       </p>
-      {(version || buildDate) && (
+      {(version || formattedBuildDate) && (
         <p className='footer-version'>
           {version && <>v{version}</>}
-          {version && buildDate && ' | '}
-          {buildDate && <>Deployed: {buildDate}</>}
+          {version && formattedBuildDate && ' | '}
+          {formattedBuildDate && <>Deployed: {formattedBuildDate}</>}
         </p>
       )}
     </footer>

--- a/src/pages/graph/Graph.tsx
+++ b/src/pages/graph/Graph.tsx
@@ -22,7 +22,7 @@ function Graph({ graphData, isLoading }: GraphProps) {
       }}
     >
       <Typography variant='h4' component='h1' mb={1} sx={{ fontWeight: 500, textAlign: 'center' }}>
-        ROBOKOP Graphs
+        ROBOKOP Atlas
       </Typography>
       <Typography
         variant='body1'

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -29,7 +29,7 @@ export default function LandingPage() {
             tool to explore relevant publications.
           </p>
         </Card>
-        <Card title='Graph Registry' href='/graphs' icon={<DataIcon />} gradient='purple'>
+        <Card title='ROBOKOP Atlas' href='/graphs' icon={<DataIcon />} gradient='purple'>
           <p>Learn about the data in ROBOKOP and explore knowledge graph using our data browser.</p>
         </Card>
       </CardContainer>


### PR DESCRIPTION
This pull request updates branding references from "Graph Registry" and "ROBOKOP Graphs" to "ROBOKOP Atlas" across the UI, and improves the display of build information in the footer by formatting the build date and normalizing the version string.

**Branding updates:**
* Changed the main graph page heading from "ROBOKOP Graphs" to "ROBOKOP Atlas" (`src/pages/graph/Graph.tsx`).
* Updated the landing page card from "Graph Registry" to "ROBOKOP Atlas" (`src/pages/landing/index.tsx`).

**Footer improvements:**
* Updated the footer to format the build date using `formatBuildDate`, and to display the version string without a leading "v" if present (`src/components/footer/Footer.tsx`). [[1]](diffhunk://#diff-c096857ee8ce97499b45a56c3d9bc8d9cc0e0a9c25ce378eb10a235a7dddf900R3-R9) [[2]](diffhunk://#diff-c096857ee8ce97499b45a56c3d9bc8d9cc0e0a9c25ce378eb10a235a7dddf900L37-R44)