### PR TITLE
Fix query capture in PostHog

### DIFF
--- a/src/pages/queryBuilder/QueryBuilder.tsx
+++ b/src/pages/queryBuilder/QueryBuilder.tsx
@@ -102,8 +102,9 @@ export default function QueryBuilder() {
         qualifier_constraints: edge.qualifier_constraints ?? 'none',
       })
     })
+    console.log('[Submit] Pruned Query Graph:', JSON.stringify(prunedQueryGraph))
     posthog.capture('question_builder_search', {
-      query: prunedQueryGraph, // the text/structured query the user entered
+      query: JSON.stringify(prunedQueryGraph),
     })
 
     const response = await API.ara.getQuickAnswer(ara, {


### PR DESCRIPTION
This pull request makes a minor update to the `QueryBuilder` component. The main change is that the `prunedQueryGraph` is now logged to the console for debugging purposes, and the `query` property sent to PostHog analytics is stringified to ensure consistent formatting.

- Debugging improvements:
  * Added a `console.log` statement to output the `prunedQueryGraph` before submitting the query.

- Analytics tracking:
  * Changed the `query` property in the `posthog.capture` call to use a stringified version of `prunedQueryGraph` instead of the raw object.