### PR TITLE
Fix query capture in PostHog

### DIFF
--- a/src/pages/queryBuilder/QueryBuilder.tsx
+++ b/src/pages/queryBuilder/QueryBuilder.tsx
@@ -102,8 +102,9 @@ export default function QueryBuilder() {
         qualifier_constraints: edge.qualifier_constraints ?? 'none',
       })
     })
+    console.log('[Submit] Pruned Query Graph:', JSON.stringify(prunedQueryGraph))
     posthog.capture('question_builder_search', {
-      query: prunedQueryGraph, // the text/structured query the user entered
+      query: JSON.stringify(prunedQueryGraph),
     })
 
     const response = await API.ara.getQuickAnswer(ara, {


### PR DESCRIPTION
This pull request makes a small change to the `QueryBuilder` component to improve debugging and analytics. The change adds a `console.log` statement for better visibility into the pruned query graph and updates the analytics event to send the query as a JSON string.

* Added a `console.log` statement to output the pruned query graph before submitting, aiding in debugging.
* Changed the `query` property sent to the `posthog.capture` analytics event to a JSON string for consistency and easier analysis.