### PR TITLE
Switch to API for graph data display

### DIFF
--- a/src/routes/graphs/$graph_id/$graph_version/index.tsx
+++ b/src/routes/graphs/$graph_id/$graph_version/index.tsx
@@ -1,21 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { queryClient } from '../../../../utils/queryClient'
 import { useQuery } from '@tanstack/react-query'
-import { graphSchema } from '../../../../API/graphRegistry'
+import { graphMetadata, graphSchema } from '../../../../API/graphRegistry'
 import GraphId from '../../../../pages/graphId/GraphId'
-import type { GraphMetadataV2 } from '../../../../API/graphMetadata'
-
-const LOCAL_GRAPH_METADATA_URL = '/graph-metadata-new.json'
-
-const loadLocalGraphMetadata = async (): Promise<GraphMetadataV2> => {
-  const response = await fetch(LOCAL_GRAPH_METADATA_URL)
-
-  if (!response.ok) {
-    throw new Error(`Failed to load local graph metadata: ${response.statusText}`)
-  }
-
-  return response.json()
-}
 
 // export const Route = createFileRoute('/graphs/$graph_id/$graph_version/')({
 //   component: RouteComponent,
@@ -27,7 +14,7 @@ export const Route = createFileRoute('/graphs/$graph_id/$graph_version/')({
     const [v2Metadata, schemaV2] = await Promise.all([
       queryClient.ensureQueryData({
         queryKey: ['graph-metadata', params.graph_id, params.graph_version],
-        queryFn: loadLocalGraphMetadata,
+        queryFn: () => graphMetadata(params.graph_id!, params.graph_version!),
       }),
       queryClient.ensureQueryData({
         queryKey: ['graph-schema', params.graph_id, params.graph_version],
@@ -73,7 +60,7 @@ function RouteComponent() {
 
   const { data: v2Metadata, isPending: v2Pending } = useQuery({
     queryKey: ['graph-metadata', graph_id, graph_version],
-    queryFn: loadLocalGraphMetadata,
+    queryFn: () => graphMetadata(graph_id!, graph_version!),
     enabled: !!graph_id,
   })
 


### PR DESCRIPTION
This pull request refactors how graph metadata is loaded in the `/graphs/$graph_id/$graph_version/` route. Instead of using a local fetch function to retrieve metadata from a static JSON file, it now uses the `graphMetadata` API function, aligning metadata fetching with the rest of the API-based data loading.

**Data fetching improvements:**

* Replaced the local `loadLocalGraphMetadata` function and static JSON file fetch with the `graphMetadata` API function for retrieving graph metadata in both the route loader and the `useQuery` hook. [[1]](diffhunk://#diff-d757c653a6db0c175d123e9d3c783bf6d0e9e617de77c6942881574e566f23e2L4-L18) [[2]](diffhunk://#diff-d757c653a6db0c175d123e9d3c783bf6d0e9e617de77c6942881574e566f23e2L30-R17) [[3]](diffhunk://#diff-d757c653a6db0c175d123e9d3c783bf6d0e9e617de77c6942881574e566f23e2L76-R63)

**Code cleanup:**

* Removed the now-unused `loadLocalGraphMetadata` function and related constants/imports from `index.tsx`.