### PR TITLE
Sorting versions by release date

### DIFF
--- a/src/pages/graphId/Releases.tsx
+++ b/src/pages/graphId/Releases.tsx
@@ -29,6 +29,24 @@ function Releases({ releases, loading }: ReleasesProps) {
   console.log('releases', { releases, loading })
   const { graph_id, graph_version } = useParams({ strict: false })
 
+  const sortedReleases = React.useMemo(() => {
+    if (!releases) return []
+
+    return [...releases].sort((a, b) => {
+      if (a.latest && !b.latest) return -1
+      if (!a.latest && b.latest) return 1
+
+      const aTime = new Date(a.release_date).getTime()
+      const bTime = new Date(b.release_date).getTime()
+
+      if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0
+      if (Number.isNaN(aTime)) return 1
+      if (Number.isNaN(bTime)) return -1
+
+      return bTime - aTime
+    })
+  }, [releases])
+
   const isViewingVersion = (version: string, isLatest: boolean) => {
     if (!graph_version) return false
     if (graph_version === 'latest') return isLatest
@@ -91,7 +109,7 @@ function Releases({ releases, loading }: ReleasesProps) {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {releases?.map((release) => {
+                  {sortedReleases.map((release) => {
                     const isActiveVersion = isViewingVersion(release.version, release.latest)
 
                     return (


### PR DESCRIPTION
This pull request updates the `Releases` component to ensure that the list of releases is consistently sorted before rendering. The main change is the introduction of a sorting mechanism that prioritizes the latest release and then orders the remaining releases by release date (most recent first). This improves the user experience by presenting releases in a logical and predictable order.

**Release sorting improvements:**

* Added a `sortedReleases` variable using `React.useMemo` to sort the `releases` array, prioritizing the latest release and then sorting by `release_date` in descending order.
* Updated the table rendering logic to use `sortedReleases` instead of the original `releases` array, ensuring the sorted order is displayed in the UI.